### PR TITLE
Allows ina226_mbed_library interface target to be exported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,55 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ina226_mbed_library)
 
-install(DIRECTORY src DESTINATION src/ina226_mbed_library)
-install(DIRECTORY include DESTINATION src/ina226_mbed_library)
-install(FILES DESTINATION src/ina226_mbed_library/src)
-install(FILES DESTINATION src/ina226_mbed_library/include)
+include(CMakePackageConfigHelpers)
+
+file(GLOB_RECURSE SOURCES ${PROJECT_SOURCE_DIR}/src/*.cpp)
+
+foreach(SOURCE_PATH ${SOURCES})
+  get_filename_component(FILE_NAME "${SOURCE_PATH}" NAME)
+  list(APPEND SOURCES_INSTALLED "${FILE_NAME}")
+endforeach()
+
+list(TRANSFORM SOURCES_INSTALLED PREPEND "src/${PROJECT_NAME}/src/")
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_sources(${PROJECT_NAME}
+  INTERFACE
+    "$<BUILD_INTERFACE:${SOURCES}>"
+    "$<INSTALL_INTERFACE:${SOURCES_INSTALLED}>"
+)
+
+target_include_directories(${PROJECT_NAME}
+  INTERFACE
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/src/${PROJECT_NAME}/include>"
+)
+
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-targets
+)
+
+install(EXPORT ${PROJECT_NAME}-targets
+        FILE ${PROJECT_NAME}-targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION share/${PROJECT_NAME}/cmake
+)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/src
+        DESTINATION src/${PROJECT_NAME}
+)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include
+        DESTINATION src/${PROJECT_NAME}
+)
+
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  INSTALL_DESTINATION share/${PROJECT_NAME}/cmake
+)
+
+install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+        DESTINATION share/${PROJECT_NAME}/cmake
+)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 > This program is free software. Licensed under the terms of the BSD License.
 
-**Use**
+## Usage
 
 <a href="https://github.com/branilson"><img src="https://github.com/branilson/ina226_mbed_library/raw/master/img/Screenshot_ina226.png" title="Branilson Luiz" alt="BranlsonLuiz"></a>
 
@@ -113,3 +113,31 @@ ina.readPower());
 Many other methods for reading and writing data are available in the class. See the header file for more details.
 
 <a href="https://github.com/branilson"><img src="https://github.com/branilson/ina226_mbed_library/raw/master/img/ina226_circuit.jpg" title="Branilson Luiz" alt="BranlsonLuiz"></a>
+
+## CMake Advanced
+To use the library with Mbed OS 6 by [compiling it with CMake](https://os.mbed.com/docs/mbed-os/v6.15/build-tools/use.html#build-the-project-with-cmake-advanced), just add the command
+
+```cmake
+find_package(ina226_mbed_library REQUIRED CONFIG)
+```
+
+and the link with your application, for example
+
+```cmake
+...
+
+  add_executable(${APP_TARGET}
+    src/main.cpp
+  )
+
+  target_include_directories(${APP_TARGET}
+    PRIVATE  
+      include
+  )
+
+  target_link_libraries(${APP_TARGET}
+    PRIVATE
+      mbed-os
+      ina226_mbed_library::ina226_mbed_library
+  )
+```

--- a/cmake/ina226_mbed_library-config.cmake.in
+++ b/cmake/ina226_mbed_library-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/manifest.xml
+++ b/manifest.xml
@@ -5,4 +5,5 @@
     <license>BSD</license>
     <url>https://github.com/branilson/ina226_mbed_library</url>
     <depend package="platformio"/>
+    <depend package="cmake"/>
 </package>


### PR DESCRIPTION
Allows ina226_mbed_library interface target to be exported to be cross-compiled or used in other downstream CMake files by running `find_package` command as can been seen in the README example